### PR TITLE
feat(api): add /debug/ping endpoint (demo + admin)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ These endpoints must NEVER “404 surprise” in production (demo + admin):
 - `GET /dashboard/summary?range=7d|30d|90d`
 - `GET /dashboard/transactions?...` (paginated)
 - `GET /integrations/powens/status`
+- `GET /debug/ping` -> `200 { ok: true, message: "pong", mode: "admin"|"demo", requestId }`
 
 Admin-only sensitive routes:
 

--- a/apps/api/AGENT.md
+++ b/apps/api/AGENT.md
@@ -67,6 +67,7 @@ For dashboard read-model endpoints, keep DB reads in dedicated repositories/use-
 ## 5) Debug and private mode
 
 - `GET /debug/metrics` must not expose secrets.
+- `GET /debug/ping` is a cross-mode liveness endpoint (`demo` + `admin`) and must not touch DB/providers.
 - `GET /debug/health` and `GET /debug/auth` are internal diagnostics endpoints.
 - `GET /__routes` is a debug endpoint for runtime route introspection.
 - In production, `/__routes` must stay inaccessible unless `PRIVATE_ACCESS_TOKEN` is configured and provided.

--- a/apps/api/src/routes/debug/router.test.ts
+++ b/apps/api/src/routes/debug/router.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'bun:test'
+import { Elysia } from 'elysia'
+import { createDebugRoutes } from './router'
+import type { PowensRoutesDependencies } from '../integrations/powens/types'
+
+const createDebugTestApp = ({
+  mode,
+}: {
+  mode: 'admin' | 'demo'
+}) => {
+  const dependencies = {
+    db: {} as PowensRoutesDependencies['db'],
+    redisClient: {} as PowensRoutesDependencies['redisClient'],
+    env: ({
+      NODE_ENV: 'test',
+      APP_COMMIT_SHA: null,
+      APP_VERSION: null,
+      PRIVATE_ACCESS_TOKEN: null,
+      DEBUG_METRICS_TOKEN: null,
+      DATABASE_URL: 'postgres://test',
+      REDIS_URL: 'redis://test',
+      AUTH_ADMIN_EMAIL: 'givernaudenzo@gmail.com',
+      AUTH_SESSION_SECRET: 'x'.repeat(32),
+      AUTH_PASSWORD_HASH: 'pbkdf2$sha256$1$test$test',
+      AUTH_PASSWORD_HASH_SOURCE: 'AUTH_PASSWORD_HASH',
+      POWENS_CLIENT_ID: 'test-client-id',
+      POWENS_CLIENT_SECRET: 'test-client-secret',
+      APP_ENCRYPTION_KEY: 'a'.repeat(32),
+      AUTH_ALLOW_INSECURE_COOKIE_IN_PROD: false,
+      AUTH_SESSION_TTL_DAYS: 30,
+      AUTH_LOGIN_RATE_LIMIT_PER_MIN: 5,
+    } as unknown) as PowensRoutesDependencies['env'],
+  }
+
+  return new Elysia()
+    .derive(() => ({
+      auth: { mode } as const,
+      internalAuth: {
+        hasValidToken: false,
+        tokenSource: null,
+      },
+      requestMeta: {
+        requestId: 'req-test',
+        startedAtMs: 0,
+      },
+    }))
+    .use(createDebugRoutes(dependencies))
+}
+
+describe('createDebugRoutes /debug/ping', () => {
+  it('returns pong in demo mode', async () => {
+    const app = createDebugTestApp({ mode: 'demo' })
+    const response = await app.handle(new Request('http://finance-os.local/debug/ping'))
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload).toEqual({
+      ok: true,
+      message: 'pong',
+      mode: 'demo',
+      requestId: 'req-test',
+    })
+  })
+
+  it('returns pong in admin mode', async () => {
+    const app = createDebugTestApp({ mode: 'admin' })
+    const response = await app.handle(new Request('http://finance-os.local/debug/ping'))
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload).toEqual({
+      ok: true,
+      message: 'pong',
+      mode: 'admin',
+      requestId: 'req-test',
+    })
+  })
+})

--- a/apps/api/src/routes/debug/router.ts
+++ b/apps/api/src/routes/debug/router.ts
@@ -82,6 +82,16 @@ export const createDebugRoutes = ({ db, redisClient, env }: PowensRoutesDependen
   }
 
   return new Elysia({ prefix: '/debug' })
+    .get('/ping', context => {
+      ensureDebugAuthAccess(context)
+
+      return {
+        ok: true,
+        message: 'pong',
+        mode: getAuth(context).mode,
+        requestId: getRequestMeta(context).requestId,
+      }
+    })
     .get('/health', context => {
       requireInternalToken(context)
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -5,6 +5,7 @@
 ```bash
 wget -qSO- http://finance-os-api:3001/health
 wget -qSO- http://finance-os-api:3001/auth/me
+wget -qSO- http://finance-os-api:3001/debug/ping
 wget -qSO- http://finance-os-api:3001/debug/auth --header='x-internal-token: <PRIVATE_ACCESS_TOKEN>'
 wget -qSO- http://finance-os-api:3001/debug/routes --header='x-finance-os-debug-token: <DEBUG_METRICS_TOKEN>'
 ```
@@ -34,6 +35,8 @@ Notes:
 
 ## Verifier mode demo/admin
 
+- `GET /debug/ping`:
+  - `200 { ok: true, message: "pong", mode: "demo"|"admin", requestId }`
 - `GET /debug/auth` (token interne requis en prod):
   - `hasSession`, `isAdmin`, `hasInternalToken`, `mode`, `requestId`
 

--- a/scripts/smoke-api.mjs
+++ b/scripts/smoke-api.mjs
@@ -61,6 +61,12 @@ const main = async () => {
     expectedStatuses: [200],
   })
 
+  await runCheck({
+    name: 'debug_ping',
+    path: '/debug/ping',
+    expectedStatuses: [200],
+  })
+
   if (debugToken) {
     await runCheck({
       name: 'debug_routes_with_debug_token',


### PR DESCRIPTION
### Motivation

- Provide a tiny cross-mode liveness/debug endpoint to validate the agentic pipeline and allow quick health checks. 
- Ensure the endpoint works in both `demo` and `admin` modes and never touches DB or external providers.

### Description

- Add `GET /debug/ping` in `apps/api/src/routes/debug/router.ts` returning `{ ok: true, message: "pong", mode, requestId }` and honoring existing debug access gating in production. 
- Add focused tests `apps/api/src/routes/debug/router.test.ts` that assert the endpoint in both `demo` and `admin` modes. 
- Include `/debug/ping` in the smoke script `scripts/smoke-api.mjs`. 
- Update documentation and contracts in `docs/debugging.md`, `AGENTS.md`, and `apps/api/AGENT.md` to document the new endpoint and its contract.

### Testing

- Ran type checks with `pnpm api:typecheck`, which completed successfully. 
- Ran unit tests with `bun test apps/api/src/routes/debug/router.test.ts`, resulting in 2 passing tests. 
- The `scripts/smoke-api.mjs` was updated to include the `debug_ping` check for future smoke runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a71fdc326c8327bfaeed6c049e528a)