### PR TITLE
fix: isolate batch issues from spec/improve autopilot workflows

### DIFF
--- a/.github/workflows/autopilot-improve-to-draft-pr.yml
+++ b/.github/workflows/autopilot-improve-to-draft-pr.yml
@@ -24,7 +24,11 @@ jobs:
 
                       const labels = (issue.labels || []).map(l => l.name);
                       const has = (n) => labels.includes(n);
+                      const title = String(issue.title || "").toLowerCase();
 
+                      // Safety rail: keep batch/spec pipelines strictly separated to avoid batch issues entering improve->PR.
+                      if (has("batch:spec")) return;
+                      if (!title.startsWith("improve:")) return;
                       if (!has("agent:challenger") || !has("autopilot")) return;
                       if (has("pr:draft")) return;
 

--- a/.github/workflows/autopilot-spec-to-improve.yml
+++ b/.github/workflows/autopilot-spec-to-improve.yml
@@ -22,7 +22,12 @@ jobs:
 
                       const labels = (issue.labels || []).map(l => l.name);
                       const has = (n) => labels.includes(n);
+                      const title = String(issue.title || "").toLowerCase();
 
+                      // Safety rail: keep batch/spec pipelines strictly separated to avoid batch issues entering spec->improve.
+                      if (has("batch:spec")) return;
+                      if (!title.startsWith("spec:")) return;
+                      if (!has("autopilot")) return;
                       if (!has("agent:pm")) return;
                       if (has("autopilot:dispatched")) return;
                       if (has("blocked") || has("wontfix") || has("won't fix")) return;

--- a/.github/workflows/autopilot-spec-to-ready.yml
+++ b/.github/workflows/autopilot-spec-to-ready.yml
@@ -24,7 +24,11 @@ jobs:
 
             const labels = (issue.labels || []).map(l => l.name);
             const has = (n) => labels.includes(n);
+            const title = String(issue.title || "").toLowerCase();
 
+            // Safety rail: keep batch/spec pipelines strictly separated to avoid batch issues entering improve pipelines.
+            if (has("batch:spec")) return;
+            if (!title.startsWith("improve:")) return;
             if (!has("agent:challenger")) return;
             if (!has("autopilot")) return;
 


### PR DESCRIPTION
### Motivation

- A `batch:spec` issue labeled `ready` accidentally triggered the Spec->Improve pipeline, producing malformed challenger issues and breaking the batch flow; this change enforces strict separation between batch/spec/improve pipelines to prevent regressions.
- The intent is a minimal, idempotent fix touching only `.github/workflows/*` to ensure: Batch pipeline handles only `batch:spec`, Spec pipeline only `spec:`-prefixed titles, and Improve pipeline only `improve:`-prefixed titles.

### Description

- Added explicit runtime guards in `autopilot-spec-to-improve.yml` to early-return when the issue has `batch:spec`, when the title does not start with `spec:`, or when `autopilot` is missing, while preserving the existing `agent:pm` gate and other idempotency checks.
- Added explicit runtime guards in `autopilot-spec-to-ready.yml` (Improve comment -> ready) to early-return when the issue has `batch:spec`, when the title does not start with `improve:`, and preserved `agent:challenger` + `autopilot` checks; included a short safety comment explaining the separation.
- Added explicit runtime guards in `autopilot-improve-to-draft-pr.yml` to early-return when the issue has `batch:spec`, when the title does not start with `improve:`, and preserved `agent:challenger` + `autopilot` checks; included a short safety comment explaining the separation.
- Verified that the batch pipelines `autopilot-batch-to-codex.yml` and `autopilot-batch-create-specs.yml` remain bounded to `batch:spec` and `autopilot:waiting-json` / `autopilot:spawned-specs` states and were not altered.

### Testing

- Static checks performed: repo-wide scans for relevant triggers and guards with `rg` to locate `issues:` / `issue_comment:` workflows and confirm new guard lines were added, and `git diff` used to verify only the three workflow files changed; these checks passed.
- Confirmed the inserted JavaScript guards appear in the three patched files (`autopilot-spec-to-improve.yml`, `autopilot-spec-to-ready.yml`, `autopilot-improve-to-draft-pr.yml`) and that batch workflows still require `batch:spec` and `autopilot:waiting-json` / `autopilot:spawned-specs`; these inspections passed.
- Runtime event validation on GitHub could not be executed from this environment (no workflow dispatch of real repo events), so the PR includes explicit manual test steps to run on the repository for quick verification: 1) Batch case: create issue titled `batch:` with labels `batch:spec`, `agent:pm`, `autopilot`, add `ready` and confirm only `autopilot-batch-to-codex` runs and `autopilot-spec-to-improve` exits early. 2) Spec case: create `spec:` titled issue with `agent:pm` + `autopilot`, add `ready` and confirm `autopilot-spec-to-improve` runs and batch workflows ignore it. 3) Improve case: create `improve:` issue with `agent:challenger` + `autopilot`, post Codex-like comment and confirm `autopilot-spec-to-ready` labels `ready` and `autopilot-improve-to-draft-pr` runs.

- Commit and PR creation were performed locally for this patch (`git commit` succeeded and PR body prepared); no CI/runtime failures observed for the local validation steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab5a914e94832781eaebc03d420bc5)