### PR TITLE
implement: Extension ingestion aux comptes d'investissement disponibles

### DIFF
--- a/.github/agent-stubs/improve-560.md
+++ b/.github/agent-stubs/improve-560.md
@@ -1,6 +1,0 @@
-# Autopilot stub for improve #560
-
-Source improve issue: https://github.com/BigZoo92/finance-os/issues/560
-
-This file is a temporary bootstrap marker for branch/PR creation.
-Delete this file in the first real implementation patch.

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -32,6 +32,7 @@ import {
   resolvePersistedSyncSnapshot,
 } from './sync-status-persistence'
 import { shouldRunReconnectRecoverySync } from './reconnect-recovery'
+import { resolveAssetTypeFromPowensAccountType } from './powens-account-type'
 import { detectSyncIntegrityIssues } from './sync-integrity-checks'
 import { detectTransactionGaps } from './transaction-gap-detection'
 
@@ -438,14 +439,17 @@ const upsertAccounts = async (connectionId: string, accounts: PowensAccount[]) =
 
   const now = new Date()
 
-  const values = accounts
+  const normalizedAccounts = accounts
     .map(account => {
       const accountId = toStringValue(account.id)
       if (!accountId) {
         return null
       }
 
+      const parsedAccountType = parseAccountType(account.type)
+
       return {
+        assetType: resolveAssetTypeFromPowensAccountType(account.type),
         source: 'banking',
         provider: 'powens',
         providerConnectionId: connectionId,
@@ -455,7 +459,7 @@ const upsertAccounts = async (connectionId: string, accounts: PowensAccount[]) =
         name: safeString(account.name, `Compte ${accountId}`),
         iban: typeof account.iban === 'string' && account.iban.length > 0 ? account.iban : null,
         currency: parseCurrency(account.currency, 'EUR'),
-        type: parseAccountType(account.type),
+        type: parsedAccountType,
         enabled: parseEnabledFlag(account.disabled),
         balance: deriveAccountBalance(account),
         metadata: deriveAccountMetadata(account),
@@ -465,13 +469,31 @@ const upsertAccounts = async (connectionId: string, accounts: PowensAccount[]) =
     })
     .filter(value => value !== null)
 
-  if (values.length === 0) {
+  if (normalizedAccounts.length === 0) {
     return []
   }
 
+  const accountValues = normalizedAccounts.map(account => ({
+    source: account.source,
+    provider: account.provider,
+    providerConnectionId: account.providerConnectionId,
+    providerAccountId: account.providerAccountId,
+    powensAccountId: account.powensAccountId,
+    powensConnectionId: account.powensConnectionId,
+    name: account.name,
+    iban: account.iban,
+    currency: account.currency,
+    type: account.type,
+    enabled: account.enabled,
+    balance: account.balance,
+    metadata: account.metadata,
+    raw: account.raw,
+    updatedAt: account.updatedAt,
+  }))
+
   await dbClient.db
     .insert(schema.financialAccount)
-    .values(values)
+    .values(accountValues)
     .onConflictDoUpdate({
       target: schema.financialAccount.powensAccountId,
       set: {
@@ -495,8 +517,8 @@ const upsertAccounts = async (connectionId: string, accounts: PowensAccount[]) =
   await dbClient.db
     .insert(schema.asset)
     .values(
-      values.map(account => ({
-        assetType: 'cash' as const,
+      normalizedAccounts.map(account => ({
+        assetType: account.assetType,
         origin: 'provider' as const,
         source: 'banking',
         provider: 'powens',
@@ -533,7 +555,7 @@ const upsertAccounts = async (connectionId: string, accounts: PowensAccount[]) =
       },
     })
 
-  return values
+  return accountValues
 }
 
 type TransactionInsert = typeof schema.transaction.$inferInsert

--- a/apps/worker/src/powens-account-type.test.ts
+++ b/apps/worker/src/powens-account-type.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'bun:test'
+import { resolveAssetTypeFromPowensAccountType } from './powens-account-type'
+
+describe('resolveAssetTypeFromPowensAccountType', () => {
+  it('returns investment for investment-like string account types', () => {
+    expect(resolveAssetTypeFromPowensAccountType('PEA Titres')).toBe('investment')
+    expect(resolveAssetTypeFromPowensAccountType('assurance vie')).toBe('investment')
+  })
+
+  it('returns investment for structured account types with id/name hints', () => {
+    expect(resolveAssetTypeFromPowensAccountType({ id: 'market', name: 'Brokerage account' })).toBe(
+      'investment'
+    )
+  })
+
+  it('defaults to cash for non-investment or unknown types', () => {
+    expect(resolveAssetTypeFromPowensAccountType('checking')).toBe('cash')
+    expect(resolveAssetTypeFromPowensAccountType({ id: 'checking', name: 'Compte courant' })).toBe(
+      'cash'
+    )
+    expect(resolveAssetTypeFromPowensAccountType(null)).toBe('cash')
+  })
+})

--- a/apps/worker/src/powens-account-type.ts
+++ b/apps/worker/src/powens-account-type.ts
@@ -1,0 +1,52 @@
+import type { PowensAccount } from '@finance-os/powens'
+
+const INVESTMENT_TYPE_HINTS = [
+  'investment',
+  'market',
+  'security',
+  'portfolio',
+  'stock',
+  'bond',
+  'fund',
+  'pea',
+  'per',
+  'titres',
+  'assurance vie',
+  'assurance-vie',
+  'life insurance',
+] as const
+
+const normalizeAccountTypeToken = (value: string) =>
+  value
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .trim()
+
+const isInvestmentAccountType = (value: string | null) => {
+  if (!value) {
+    return false
+  }
+
+  const normalized = normalizeAccountTypeToken(value)
+
+  return INVESTMENT_TYPE_HINTS.some(hint => normalized.includes(hint))
+}
+
+export const resolveAssetTypeFromPowensAccountType = (
+  value: PowensAccount['type']
+): 'cash' | 'investment' => {
+  if (typeof value === 'string') {
+    return isInvestmentAccountType(value) ? 'investment' : 'cash'
+  }
+
+  if (value && typeof value === 'object') {
+    const objectTypeHints = [value.id, value.name]
+      .filter((hint): hint is string => typeof hint === 'string' && hint.length > 0)
+      .some(hint => isInvestmentAccountType(hint))
+
+    return objectTypeHints ? 'investment' : 'cash'
+  }
+
+  return 'cash'
+}


### PR DESCRIPTION
Parent improve issue: #560

Source improve issue: https://github.com/BigZoo92/finance-os/issues/560

Autopilot mode: manual Codex handoff.
Open this PR task in Codex and extract the implementation manually onto this branch.
Autopilot will merge automatically once the branch is real, green, and up to date.