### PR TITLE
docs(agentic): add high-rigor policy + verification bundle for medium-high risk changes

### DIFF
--- a/.agents/skills/code-change-verification/SKILL.md
+++ b/.agents/skills/code-change-verification/SKILL.md
@@ -28,8 +28,9 @@ description: Run the smallest reliable verification set for a Finance-OS change 
 
 1. Start from [../../../docs/agentic/testing-map.md](../../../docs/agentic/testing-map.md) and the nearest local `AGENTS.md`.
 2. Run the smallest relevant checks first instead of defaulting to the full repo suite.
-3. Include the agentic validator when `AGENTS.md`, `.agents/skills/`, or `docs/agentic/` changed.
-4. Escalate to broader checks only if the scope or failures justify it.
+3. For medium-high risk changes, include the checklist and decision trees from [../../../docs/agentic/policy-verification-bundle.md](../../../docs/agentic/policy-verification-bundle.md) in the verification note.
+4. Include the agentic validator when `AGENTS.md`, `.agents/skills/`, or `docs/agentic/` changed.
+5. Escalate to broader checks only if the scope or failures justify it.
 
 ## Trigger Examples
 

--- a/.agents/skills/dual-path-guard/SKILL.md
+++ b/.agents/skills/dual-path-guard/SKILL.md
@@ -26,9 +26,11 @@ description: Verify Finance-OS demo/admin dual-path correctness. Use when auth, 
 ## Workflow
 
 1. Read [../../../AGENTS.md](../../../AGENTS.md), [../../../apps/api/AGENTS.md](../../../apps/api/AGENTS.md), and [../../../apps/web/AGENTS.md](../../../apps/web/AGENTS.md).
-2. Confirm demo returns or mocks happen before DB, Redis, or provider calls.
-3. Confirm admin-only actions remain gated in both API and UI surfaces.
-4. Confirm SSR auth fallback still lands in demo cleanly instead of failing hard or flashing the wrong state.
+2. Use the dual-path decision tree in [../../../docs/agentic/policy-verification-bundle.md](../../../docs/agentic/policy-verification-bundle.md) to classify each touched flow as pass/fail.
+3. Confirm demo returns or mocks happen before DB, Redis, or provider calls.
+4. Confirm admin-only actions remain gated in both API and UI surfaces.
+5. Confirm SSR auth fallback still lands in demo cleanly instead of failing hard or flashing the wrong state.
+6. Require explicit negative-test evidence for: demo no-live-calls, demo no-writes, and unauthorized admin mutation denial.
 
 ## Trigger Examples
 
@@ -39,3 +41,4 @@ description: Verify Finance-OS demo/admin dual-path correctness. Use when auth, 
 
 - Use [../../../docs/agentic/contracts-map.md](../../../docs/agentic/contracts-map.md) for route expectations.
 - Use [../../../docs/agentic/testing-map.md](../../../docs/agentic/testing-map.md) to decide whether the current coverage is enough.
+- Mirror the acceptance criteria and required negative tests in [../../../docs/agentic/policy-verification-bundle.md](../../../docs/agentic/policy-verification-bundle.md) for medium-high risk changes.

--- a/.agents/skills/release-sanity/SKILL.md
+++ b/.agents/skills/release-sanity/SKILL.md
@@ -32,6 +32,7 @@ description: Validate whether a Finance-OS change can affect CI, release, deploy
 4. When autopilot implementation flow is in scope, verify the draft PR request comment, PR-thread patch apply, single active PR lane, stub-only rejection, and merge-on-green rebase/merge assumptions together.
 5. Prefer validation and documentation over redesign; do not expand scope into workflow rewrites unless asked.
 6. Call out any smoke checks from [../../../scripts/smoke-api.mjs](../../../scripts/smoke-api.mjs) or [../../../scripts/smoke-prod.mjs](../../../scripts/smoke-prod.mjs) that should run, including the post-deploy `/health`, `/auth/me`, `/dashboard/summary`, and `/integrations/powens/status` coverage plus any required `SMOKE_AUTH_MODE` or smoke-admin secrets.
+7. For medium-high risk changes, verify staged rollout and emergency downgrade readiness using [../../../docs/agentic/policy-verification-bundle.md](../../../docs/agentic/policy-verification-bundle.md).
 
 ## Trigger Examples
 

--- a/.agents/skills/ui-change-quality/SKILL.md
+++ b/.agents/skills/ui-change-quality/SKILL.md
@@ -29,7 +29,8 @@ description: Review Finance-OS UI changes for loader-first data flow, state cove
 1. Read [../../../apps/web/AGENTS.md](../../../apps/web/AGENTS.md) and [../../../docs/agentic/ui-quality-map.md](../../../docs/agentic/ui-quality-map.md).
 2. Verify the change still respects loader-first data flow and SSR auth consistency.
 3. Check that shared primitives in [../../../packages/ui/AGENTS.md](../../../packages/ui/AGENTS.md) remain generic and accessible.
-4. Capture the shortest useful rationale and screenshot checklist for review.
+4. Validate full UI state coverage against [../../../docs/agentic/policy-verification-bundle.md](../../../docs/agentic/policy-verification-bundle.md) (loading, empty, success, degraded, recoverable error, and gated states).
+5. Capture the shortest useful rationale and screenshot checklist for review.
 
 ## Trigger Examples
 

--- a/docs/agentic/INDEX.md
+++ b/docs/agentic/INDEX.md
@@ -10,6 +10,7 @@ Use these files as markdown-first entry points before re-exploring the repo.
 - [ui-quality-map.md](ui-quality-map.md): UI quality bar, key surfaces, and manual UI checks
 - [release-map.md](release-map.md): CI, autopilot, release, deploy, and smoke-test entrypoints
 - [code_review.md](code_review.md): practical review severity and checklist for this repo
+- [policy-verification-bundle.md](policy-verification-bundle.md): conventions, decision trees, and high-effort verification checklists for dual-path parity, observability, UI states, and rollback
 
 ## Local Guides
 

--- a/docs/agentic/code_review.md
+++ b/docs/agentic/code_review.md
@@ -16,6 +16,7 @@ Use this guide for reviews in this repo.
 - Required HTTP contracts still exist and still return the expected auth-safe shape
 - Verification matches the changed scope
 - Observability contracts still line up: `x-request-id` propagation, structured/safe logs, smoke checks, healthcheck targets, and alert probe wiring
+- For medium-high risk changes, require the decision-tree and checklist evidence from [policy-verification-bundle.md](policy-verification-bundle.md).
 
 ## UI-Specific Checks
 

--- a/docs/agentic/policy-verification-bundle.md
+++ b/docs/agentic/policy-verification-bundle.md
@@ -1,0 +1,176 @@
+# Policy + Verification Bundle (High-Rigor)
+
+Use this bundle when a change has a medium-high risk profile, broad blast radius, or unclear fallback behavior. This is the "most robust, highest-effort" baseline.
+
+## Conventions
+
+- Preserve explicit dual-path behavior (`demo` default mock path, `admin` gated live path) for every changed flow.
+- Encode fallback-first behavior: integration failures must degrade to a usable surface with safe copy and no secret leakage.
+- Keep observability normalized end-to-end:
+  - request correlation via `x-request-id`
+  - structured logs only
+  - safe, normalized error payloads
+  - release smoke coverage aligned with public `web` ingress
+- Treat UI states as a contract (not a cosmetic detail): loading, empty, success, recoverable error, and degraded-fallback states must be explicit.
+- Couple rollout and rollback design to kill-switches before merge; do not ship behavior that cannot be disabled quickly.
+
+## Decision Trees
+
+### 1) Demo/Admin Parity Decision Tree
+
+```mermaid
+flowchart TD
+  A[Changed route/loader/action] --> B{Does demo branch short-circuit first?}
+  B -- No --> B1[Fail: P0/P1 depending on data/provider touch]
+  B -- Yes --> C{Any DB/provider call reachable in demo?}
+  C -- Yes --> C1[Fail: add guard + negative test]
+  C -- No --> D{Are admin writes gated by session or signed internal state?}
+  D -- No --> D1[Fail: restore admin guard]
+  D -- Yes --> E{SSR first render stable (no demo/admin flash)?}
+  E -- No --> E1[Fail: fix auth resolution path]
+  E -- Yes --> F[Pass dual-path review]
+```
+
+### 2) Observability/Failure Decision Tree
+
+```mermaid
+flowchart TD
+  A[New event/error surface] --> B{Includes x-request-id?}
+  B -- No --> B1[Fail: wire request-id propagation]
+  B -- Yes --> C{Payload normalized + secret-safe?}
+  C -- No --> C1[Fail: normalize payload and redact]
+  C -- Yes --> D{SLO counters updated?}
+  D -- No --> D1[Fail: add/update counters]
+  D -- Yes --> E{Smoke/health checks still match route topology?}
+  E -- No --> E1[Fail: update smoke checks/probes]
+  E -- Yes --> F[Pass observability review]
+```
+
+### 3) Rollback/Kill-switch Decision Tree
+
+```mermaid
+flowchart TD
+  A[Feature touches runtime behavior] --> B{Has explicit kill-switch?}
+  B -- No --> B1[Block release until kill-switch exists]
+  B -- Yes --> C{Can disable without DB migration rollback?}
+  C -- No --> C1[Add compatibility shim or rollback step]
+  C -- Yes --> D{Can downgrade in <=15 min with runbook steps?}
+  D -- No --> D1[Document emergency downgrade procedure]
+  D -- Yes --> E[Ready for staged rollout]
+```
+
+## Required Verification Checklist
+
+Use this checklist in PR notes for medium-high risk changes.
+
+### A. Demo/Admin Dual-Path Acceptance Criteria
+
+#### Demo path (must all pass)
+- Deterministic mock data renders for all touched routes/components.
+- No DB, Redis, or provider side effects from demo execution path.
+- Sensitive actions are visibly disabled or read-only.
+- Error/fallback messaging stays actionable (no dead-end state).
+
+#### Admin path (must all pass)
+- Authenticated admin can perform expected reads/writes.
+- Unauthorized/non-admin attempts fail with safe payloads.
+- SSR auth resolves admin on first render without demo flash.
+- Provider/API failures degrade to partial-but-usable UI.
+
+#### Required negative tests
+- Demo request never triggers live provider call.
+- Demo request never writes DB state (even through helper paths).
+- Admin-only mutation denied without valid session/signed state.
+- Invalid provider callback/auth-state fails closed with safe error body.
+
+### B. Observability Contract Acceptance Criteria
+
+- `x-request-id` exists in:
+  - ingress request context
+  - structured log events
+  - error payload surface where already contractually exposed
+- Event and error payloads are normalized and safe.
+- Smoke checks and probes still cover affected route topology.
+
+#### Normalized payload examples
+
+**Event (structured log)**
+
+```json
+{
+  "level": "info",
+  "event": "dashboard.summary.fetch",
+  "requestId": "req_123",
+  "mode": "demo",
+  "status": "fallback",
+  "reasonCode": "provider_unavailable",
+  "safeContext": {
+    "route": "/dashboard/summary"
+  }
+}
+```
+
+**Error payload (safe for clients)**
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "POWENS_SYNC_DEGRADED",
+    "message": "Sync is temporarily unavailable. Showing last safe snapshot.",
+    "requestId": "req_123"
+  }
+}
+```
+
+#### SLO-facing counters (minimum set)
+- `finance_os_request_total{route,mode,status}`
+- `finance_os_request_error_total{route,mode,error_code}`
+- `finance_os_fallback_total{route,dependency,reason_code}`
+- `finance_os_degraded_serving_total{surface,mode}`
+
+## UI/UX State Catalog + Screenshot Expectations
+
+For each touched UI surface, explicitly document whether every state below exists and how it is reached.
+
+- Loading (skeleton/preloaded content strategy)
+- Empty (first-use/no-data)
+- Success (fresh data)
+- Degraded success (stale-but-usable/fallback snapshot)
+- Recoverable error (retry path)
+- Blocking error (if truly unavoidable)
+- Offline/network-loss hint (if applicable)
+- Permission-gated (demo/admin affordance differences)
+- In-progress mutation + post-success confirmation
+
+### Screenshot expectations for review
+
+Include screenshots for:
+1. Primary success state (desktop).
+2. Degraded fallback state with safe explanatory copy.
+3. Error/retry state.
+4. Demo/admin gating evidence when UI affordances differ.
+
+If a state is hard to force, explain deterministic repro steps in PR notes.
+
+## Staged Rollout + Emergency Downgrade
+
+### Staged rollout policy
+
+1. **Dark launch**: land code paths behind a runtime kill-switch (default off in production).
+2. **Internal enablement**: enable for admin path only and validate smoke + manual checklist.
+3. **Progressive exposure**: widen to intended audience while monitoring SLO counters and fallback rates.
+4. **Steady-state**: remove temporary guards only after at least one stable release window.
+
+### Emergency downgrade procedure
+
+1. Flip the runtime kill-switch to disable the risky path.
+2. Confirm health and smoke checks (`/health`, `/auth/me`, `/dashboard/summary`, `/integrations/powens/status`).
+3. Verify demo/admin parity remains intact in safe mode.
+4. Announce incident status with request-id samples and normalized reason codes (no secrets).
+5. If needed, redeploy last known good image tag (immutable tag, never `latest`).
+
+## Risk and Delivery Guidance
+
+- Expected risk profile: **medium-high** for this bundle due to larger change surface and verification overhead.
+- Delivery tradeoff: this policy can slow immediate throughput but significantly lowers fallback/contract regressions.

--- a/docs/agentic/release-map.md
+++ b/docs/agentic/release-map.md
@@ -46,6 +46,7 @@ This repo already has a working automation model. Treat this map as an entry poi
 - Treat observability wiring as release-sensitive: `x-request-id` visibility, smoke coverage, healthcheck targets, and alert probe URLs must continue to match the public `web` entrypoint and the internal API/worker topology.
 - Runtime-safe web feature flags must stay aligned across build args, `docker-compose.prod*.yml`, Dokploy env, and `public-runtime-env.ts`; that now includes the dashboard health signal flags alongside the existing Powens cooldown UI flags.
 - Server-side Powens kill-switches that change worker/API write behavior, such as `SYNC_STATUS_PERSISTENCE_ENABLED`, `POWENS_FORCE_FULL_SYNC`, and `POWENS_SYNC_DISABLED_PROVIDERS`, must stay aligned across the API and worker runtime env in `docker-compose.prod.yml` and the Dokploy env snapshot even though they are not build args or `VITE_*` flags.
+- Medium-high risk work should follow the staged rollout and emergency downgrade guidance in [policy-verification-bundle.md](policy-verification-bundle.md), including explicit kill-switch validation before release readiness.
 
 ## Smoke and Manual Checks
 

--- a/docs/agentic/testing-map.md
+++ b/docs/agentic/testing-map.md
@@ -39,6 +39,9 @@ Use this map to choose the smallest verification set that still matches the risk
 
 ## Scope-Based Verification
 
+- Medium-high risk policy/documentation bundle changes:
+  - `node .agents/skills/scripts/validate-agent-foundation.mjs`
+  - Apply the required checklist in [policy-verification-bundle.md](policy-verification-bundle.md), including dual-path negative tests and fallback assertions.
 - Docs, AGENTS, or skills only:
   - `node .agents/skills/scripts/validate-agent-foundation.mjs`
 - API auth or contract changes:
@@ -131,6 +134,7 @@ Use this map to choose the smallest verification set that still matches the risk
 ## Manual Checks Worth Doing
 
 - Demo mode: dashboard loads mock summary, transactions, and Powens status with sensitive actions disabled.
+- Demo/admin parity acceptance: verify the touched flow against [policy-verification-bundle.md](policy-verification-bundle.md) for explicit pass criteria on each path plus required negative tests.
 - Transactions freshness UX: latest transactions card shows "Last updated" plus distinct freshness badges (`fresh`, `stale-but-usable`, `syncing`, `sync-failed-with-safe-data`, `no-data-first-connect`) without blocking the table behind a spinner-only state.
 - Dashboard health indicators: global summary and selective inline badges stay aligned in both demo and admin, and the diagnosis drawer explains the same normalized reason codes shown in logs.
 - Powens connection badges: `OK`, `KO`, `En cours`, and `Inconnu` render the expected short reason, the tooltip shows the last attempt time, and `SYNC_STATUS_PERSISTENCE_ENABLED=false` downgrades immediately to runtime placeholders without stale persisted status leaking through.
@@ -140,3 +144,4 @@ Use this map to choose the smallest verification set that still matches the risk
 - Admin mode: the goals drawer can create, update, and archive goals, with recoverable error messaging and a visible request id when a write fails.
 - Powens callback: invalid auth/state fails safely, valid admin/state flow returns success and queues sync.
 - Release-sensitive changes: run the smoke scripts in [../../scripts/smoke-api.mjs](../../scripts/smoke-api.mjs) and [../../scripts/smoke-prod.mjs](../../scripts/smoke-prod.mjs) with the right env; prod smoke now covers `/health`, `/auth/me`, `/dashboard/summary`, and `/integrations/powens/status`, plus optional demo/admin auth context via `SMOKE_AUTH_MODE`.
+- Rollback readiness: verify kill-switch behavior and emergency downgrade steps from [policy-verification-bundle.md](policy-verification-bundle.md) before marking medium-high risk work as release-ready.

--- a/docs/agentic/ui-quality-map.md
+++ b/docs/agentic/ui-quality-map.md
@@ -23,6 +23,7 @@ Use this map when touching dashboard surfaces or shared UI primitives.
 
 - Add a short UI rationale in the PR summary or change notes.
 - Include screenshot notes for meaningful UI changes.
+- For medium-high risk changes, include the full state catalog and screenshot matrix from [policy-verification-bundle.md](policy-verification-bundle.md).
 - If a shared primitive changes, check both the consuming web page and the package export surface.
 
 ## Manual UI Checklist
@@ -39,3 +40,4 @@ Use this map when touching dashboard surfaces or shared UI primitives.
 - Mobile and desktop layouts still load without overflow surprises.
 - When the Powens sync cooldown UI guard is enabled, the dashboard should clearly show `Idle -> Syncing -> Cooldown -> Ready`, keep blocked reason text explicit, and still honor demo/admin gating plus the runtime kill-switch.
 - Reconnect-required states should surface as a non-blocking inline banner at the top of dashboard with explicit `Reconnecter` and `Plus tard` CTAs, full loading/in-progress/error/deferred state copy, and deterministic demo behavior behind `VITE_UI_RECONNECT_BANNER_ENABLED`.
+- Capture screenshots for at least success, degraded fallback, and error/retry states when those states are user-visible in the touched UI.


### PR DESCRIPTION
### Motivation
- Provide a single, high‑rigor playbook for medium-high risk work that enforces demo/admin parity, robust observability, explicit UI state coverage, and rollback readiness.
- Ensure agentic skills and the testing/release guidance require the same formal decision trees and negative-test evidence so reviewers and automation apply a consistent bar.

### Description
- Add `docs/agentic/policy-verification-bundle.md` containing conventions, three decision trees (demo/admin parity, observability, rollback), required verification checklists, normalized payload examples, SLO counters, UI state catalog, screenshot expectations, and staged rollout/emergency downgrade guidance.
- Link the new bundle from `docs/agentic/INDEX.md` and wire it into the maps by updating `docs/agentic/testing-map.md`, `docs/agentic/ui-quality-map.md`, `docs/agentic/release-map.md`, and `docs/agentic/code_review.md` to require or recommend the bundle for medium-high risk changes.
- Update agentic skills so they consume the bundle: ` .agents/skills/dual-path-guard/SKILL.md`, ` .agents/skills/code-change-verification/SKILL.md`, ` .agents/skills/ui-change-quality/SKILL.md`, and ` .agents/skills/release-sanity/SKILL.md` now reference the decision trees/checklist and require explicit negative-test evidence or rollback validation where applicable.
- Add checklist enforcement points (demo no-live-calls, demo no-writes, unauthorized admin mutation denial, kill-switch verification) into the verification guidance used by skills and maps.

### Testing
- Ran the agentic foundation validator with `node .agents/skills/scripts/validate-agent-foundation.mjs`, which passed and reported: "Agent foundation validation passed: 1 root AGENTS, 9 nested AGENTS, 7 docs, 11 skills."

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2ab519b1c8327a7d966326564873b)